### PR TITLE
added genmet,  pfmet, puppimet, chsjets, puppijets, tau cut based 4WPs

### DIFF
--- a/bin/Ntuplizer.py
+++ b/bin/Ntuplizer.py
@@ -503,9 +503,13 @@ class TreeProducer:
             self.tau_decaymode  [i]  = 0. # dummy for now, has to be implemented in Delphes
             self.tau_reliso     [i]  = 0. # dummy for now, has to be implemented in Delphes
 
-            ## Tau-Tagging (for now only cut based ID, corresponds to 1st BIT in Delphes) ### TO BE FIXED !!!
+            ## Tau-Tagging (including the 4WPs cut based)
             if ( item.TauTag & (1 << 0) ):
                 self.tau_isopass    [i] |= 1 << 0
+
+            for j in range(4):
+                if ( item.tau_isopass & (1 << j) ):
+                    self.tau_isopass[i] |= 1 << j
 
             i += 1
         self.tau_size[0] = i

--- a/bin/Ntuplizer.py
+++ b/bin/Ntuplizer.py
@@ -85,7 +85,6 @@ class TreeProducer:
          self.tau_charge       = array( 'i', self.maxn*[ 0 ] )
          self.tau_decaymode    = array( 'f', self.maxn*[ 0. ] )
          self.tau_reliso       = array( 'f', self.maxn*[ 0. ] )
-         self.tau_isofunction  = array( 'f', self.maxn*[ 0. ] )
          self.tau_isopass      = array( 'i', self.maxn*[ 0 ] )
 
          self.jetpuppi_size         = array( 'i', [ 0 ] )
@@ -182,7 +181,6 @@ class TreeProducer:
          self.t.Branch( "tau_charge",self.tau_charge, "tau_charge[tau_size]/I")
          self.t.Branch( "tau_decaymode",self.tau_decaymode, "tau_decaymode[tau_size]/F")
          self.t.Branch( "tau_reliso",self.tau_reliso, "tau_reliso[tau_size]/F")
-         self.t.Branch( "tau_isofunction",self.tau_isofunction, "tau_isofunction[tau_size]/F")
          self.t.Branch( "tau_isopass",self. tau_isopass, "tau_isopass[tau_size]/i")
 
          self.t.Branch( "jetpuppi_size",self.jetpuppi_size, "jetpuppi_size/I")
@@ -504,7 +502,6 @@ class TreeProducer:
             self.tau_charge     [i]  = item.Charge
             self.tau_decaymode  [i]  = 0. # dummy for now, has to be implemented in Delphes
             self.tau_reliso     [i]  = 0. # dummy for now, has to be implemented in Delphes
-            self.tau_isofunction[i]  = 0. # dummy for now, has to be implemented in Delphes
 
             ## Tau-Tagging (for now only cut based ID, corresponds to 1st BIT in Delphes) ### TO BE FIXED !!!
             if ( item.TauTag & (1 << 0) ):

--- a/bin/Ntuplizer.py
+++ b/bin/Ntuplizer.py
@@ -41,6 +41,10 @@ class TreeProducer:
          self.genjet_phi       = array( 'f', self.maxn*[ 0. ] )
          self.genjet_mass      = array( 'f', self.maxn*[ 0. ] )
 
+         self.genmet_size      = array( 'i', [ 0 ] )
+         self.genmet_pt        = array( 'f', self.maxn*[ 0. ] )
+         self.genmet_phi       = array( 'f', self.maxn*[ 0. ] )
+
          self.gamma_size       = array( 'i', [ 0 ] )
          self.gamma_pt         = array( 'f', self.maxn*[ 0. ] )
          self.gamma_eta        = array( 'f', self.maxn*[ 0. ] )
@@ -84,18 +88,31 @@ class TreeProducer:
          self.tau_isofunction  = array( 'f', self.maxn*[ 0. ] )
          self.tau_isopass      = array( 'i', self.maxn*[ 0 ] )
 
-         self.jet_size         = array( 'i', [ 0 ] )
-         self.jet_pt           = array( 'f', self.maxn*[ 0. ] )
-         self.jet_eta          = array( 'f', self.maxn*[ 0. ] )
-         self.jet_phi          = array( 'f', self.maxn*[ 0. ] )
-         self.jet_mass         = array( 'f', self.maxn*[ 0. ] )
-         self.jet_idpass       = array( 'i', self.maxn*[ 0 ] )
-         self.jet_DeepJET      = array( 'f', self.maxn*[ 0. ] )
-         self.jet_btag         = array( 'i', self.maxn*[ 0 ] )
+         self.jetpuppi_size         = array( 'i', [ 0 ] )
+         self.jetpuppi_pt           = array( 'f', self.maxn*[ 0. ] )
+         self.jetpuppi_eta          = array( 'f', self.maxn*[ 0. ] )
+         self.jetpuppi_phi          = array( 'f', self.maxn*[ 0. ] )
+         self.jetpuppi_mass         = array( 'f', self.maxn*[ 0. ] )
+         self.jetpuppi_idpass       = array( 'i', self.maxn*[ 0 ] )
+         self.jetpuppi_DeepJET      = array( 'f', self.maxn*[ 0. ] )
+         self.jetpuppi_btag         = array( 'i', self.maxn*[ 0 ] )
 
-         self.met_size         = array( 'i', [ 0 ] )
-         self.met_pt           = array( 'f', self.maxn*[ 0. ] )
-         self.met_phi          = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_size         = array( 'i', [ 0 ] )
+         self.jetchs_pt           = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_eta          = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_phi          = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_mass         = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_idpass       = array( 'i', self.maxn*[ 0 ] )
+         self.jetchs_DeepJET      = array( 'f', self.maxn*[ 0. ] )
+         self.jetchs_btag         = array( 'i', self.maxn*[ 0 ] )
+
+         self.metpuppi_size         = array( 'i', [ 0 ] )
+         self.metpuppi_pt           = array( 'f', self.maxn*[ 0. ] )
+         self.metpuppi_phi          = array( 'f', self.maxn*[ 0. ] )
+
+         self.metpf_size         = array( 'i', [ 0 ] )
+         self.metpf_pt           = array( 'f', self.maxn*[ 0. ] )
+         self.metpf_phi          = array( 'f', self.maxn*[ 0. ] )
 
          # declare tree branches
          self.t.Branch( "evt_size",self.evt_size, "evt_size/I")
@@ -120,6 +137,10 @@ class TreeProducer:
          self.t.Branch( "genjet_eta",self.genjet_eta, "genjet_eta[genjet_size]/F")
          self.t.Branch( "genjet_phi",self.genjet_phi, "genjet_phi[genjet_size]/F")
          self.t.Branch( "genjet_mass",self.genjet_mass, "genjet_mass[genjet_size]/F")
+
+         self.t.Branch( "genmet_size",self.genmet_size, "genmet_size/I")
+         self.t.Branch( "genmet_pt",self.genmet_pt, "genmet_pt[genmet_size]/F")
+         self.t.Branch( "genmet_phi",self.genmet_phi, "genmet_phi[genmet_size]/F")
 
          self.t.Branch( "gamma_size",self.gamma_size, "gamma_size/I")
          self.t.Branch( "gamma_pt",self.gamma_pt, "gamma_pt[gamma_size]/F")
@@ -164,18 +185,31 @@ class TreeProducer:
          self.t.Branch( "tau_isofunction",self.tau_isofunction, "tau_isofunction[tau_size]/F")
          self.t.Branch( "tau_isopass",self. tau_isopass, "tau_isopass[tau_size]/i")
 
-         self.t.Branch( "jet_size",self.jet_size, "jet_size/I")
-         self.t.Branch( "jet_pt",self.jet_pt, "jet_pt[jet_size]/F")
-         self.t.Branch( "jet_eta",self.jet_eta, "jet_eta[jet_size]/F")
-         self.t.Branch( "jet_phi",self.jet_phi, "jet_phi[jet_size]/F")
-         self.t.Branch( "jet_mass",self.jet_mass, "jet_mass[jet_size]/F")
-         self.t.Branch( "jet_idpass",self. jet_idpass, "jet_idpass[jet_size]/i")
-         self.t.Branch( "jet_DeepJET",self.jet_DeepJET,"jet_DeepJET[jet_size]/F")
-         self.t.Branch( "jet_btag",self.jet_btag,"jet_btag[jet_size]/I")
+         self.t.Branch( "jetpuppi_size",self.jetpuppi_size, "jetpuppi_size/I")
+         self.t.Branch( "jetpuppi_pt",self.jetpuppi_pt, "jetpuppi_pt[jetpuppi_size]/F")
+         self.t.Branch( "jetpuppi_eta",self.jetpuppi_eta, "jetpuppi_eta[jetpuppi_size]/F")
+         self.t.Branch( "jetpuppi_phi",self.jetpuppi_phi, "jetpuppi_phi[jetpuppi_size]/F")
+         self.t.Branch( "jetpuppi_mass",self.jetpuppi_mass, "jetpuppi_mass[jetpuppi_size]/F")
+         self.t.Branch( "jetpuppi_idpass",self. jetpuppi_idpass, "jetpuppi_idpass[jetpuppi_size]/i")
+         self.t.Branch( "jetpuppi_DeepJET",self.jetpuppi_DeepJET,"jetpuppi_DeepJET[jetpuppi_size]/F")
+         self.t.Branch( "jetpuppi_btag",self.jetpuppi_btag,"jetpuppi_btag[jetpuppi_size]/I")
 
-         self.t.Branch( "met_size",self.met_size, "met_size/I")
-         self.t.Branch( "met_pt",self. met_pt, "met_pt[met_size]/F")
-         self.t.Branch( "met_phi",self.met_phi, "met_phi[met_size]/F")
+         self.t.Branch( "jetchs_size",self.jetchs_size, "jetchs_size/I")
+         self.t.Branch( "jetchs_pt",self.jetchs_pt, "jetchs_pt[jetchs_size]/F")
+         self.t.Branch( "jetchs_eta",self.jetchs_eta, "jetchs_eta[jetchs_size]/F")
+         self.t.Branch( "jetchs_phi",self.jetchs_phi, "jetchs_phi[jetchs_size]/F")
+         self.t.Branch( "jetchs_mass",self.jetchs_mass, "jetchs_mass[jetchs_size]/F")
+         self.t.Branch( "jetchs_idpass",self. jetchs_idpass, "jetchs_idpass[jetchs_size]/i")
+         self.t.Branch( "jetchs_DeepJET",self.jetchs_DeepJET,"jetchs_DeepJET[jetchs_size]/F")
+         self.t.Branch( "jetchs_btag",self.jetchs_btag,"jetchs_btag[jetchs_size]/I")
+
+         self.t.Branch( "metpuppi_size",self.metpuppi_size, "metpuppi_size/I")
+         self.t.Branch( "metpuppi_pt",self. metpuppi_pt, "metpuppi_pt[metpuppi_size]/F")
+         self.t.Branch( "metpuppi_phi",self.metpuppi_phi, "metpuppi_phi[metpuppi_size]/F")
+
+         self.t.Branch( "metpf_size",self.metpf_size, "metpf_size/I")
+         self.t.Branch( "metpf_pt",self. metpf_pt, "metpf_pt[metpf_size]/F")
+         self.t.Branch( "metpf_phi",self.metpf_phi, "metpf_phi[metpf_size]/F")
 
     #___________________________________________
     def processEvent(self, entry):
@@ -206,7 +240,6 @@ class TreeProducer:
             i += 1
         self.genpart_size[0] = i
 
-
     #___________________________________________
     def processGenJets(self, genjets):
         i = 0
@@ -218,6 +251,15 @@ class TreeProducer:
             i += 1
         self.genjet_size[0] = i
 
+    #___________________________________________
+    def processGenMissingET(self, met):
+        i = 0
+        for item in met:
+
+            self.genmet_pt    [i] = item.MET
+            self.genmet_phi   [i] = item.Phi
+            i += 1
+        self.genmet_size  [0] = i
 
     #___________________________________________
     def processPhotons(self, photons, photons_loose, photons_medium, photons_tight):
@@ -347,16 +389,16 @@ class TreeProducer:
         self.muon_size[0] = i
 
     #___________________________________________
-    def processJets(self, jets):
+    def processPuppiJets(self, jets):
 
         i = 0
         for item in jets:
             jetp4 = item.P4()
-            self.jet_pt      [i] = jetp4.Pt()
-            self.jet_eta     [i] = jetp4.Eta()
-            self.jet_phi     [i] = jetp4.Phi()
-            self.jet_mass    [i] = jetp4.M()
-            self.jet_idpass  [i] = 0             # DUMMY 
+            self.jetpuppi_pt      [i] = jetp4.Pt()
+            self.jetpuppi_eta     [i] = jetp4.Eta()
+            self.jetpuppi_phi     [i] = jetp4.Phi()
+            self.jetpuppi_mass    [i] = jetp4.M()
+            self.jetpuppi_idpass  [i] = 0             # DUMMY 
 
             ### JETID: Jet constituents seem to broken!! For now set all Jet ID to True TO BE FIXED ######
 
@@ -385,21 +427,66 @@ class TreeProducer:
             if self.debug : print '   jet const sum: ', p4tot.Pt(), p4tot.Eta(), p4tot.Phi(), p4tot.M()
             if self.debug : print '   jet          : ', jetp4.Pt(), jetp4.Eta(), jetp4.Phi(), jetp4.M()
 
-            self.jet_idpass[i] |= 1 << 0
-            self.jet_idpass[i] |= 1 << 1
-            self.jet_idpass[i] |= 1 << 2
+            self.jetpuppi_idpass[i] |= 1 << 0
+            self.jetpuppi_idpass[i] |= 1 << 1
+            self.jetpuppi_idpass[i] |= 1 << 2
 
             #### BTagging
 
-            self.jet_DeepJET [i] = 0.  ## some dummy value
+            self.jetpuppi_DeepJET [i] = 0.  ## some dummy value
 
             for j in range(3):
                 if ( item.BTag & (1 << j) ):
-                    self.jet_btag[i] |= 1 << j
+                    self.jetpuppi_btag[i] |= 1 << j
 
             i += 1
-        self.jet_size[0] = i
+        self.jetpuppi_size[0] = i
 
+    #___________________________________________
+    def processCHSJets(self, jets):
+
+        i = 0
+        for item in jets:
+            jetp4 = item.P4()
+            self.jetchs_pt      [i] = jetp4.Pt()
+            self.jetchs_eta     [i] = jetp4.Eta()
+            self.jetchs_phi     [i] = jetp4.Phi()
+            self.jetchs_mass    [i] = jetp4.M()
+            self.jetchs_idpass  [i] = 0             # DUMMY 
+
+            ### JETID: Jet constituents seem to broken!! For now set all Jet ID to True TO BE FIXED ######
+
+            # compute jet id by looping over jet constituents
+            if self.debug : print '   new jet: ', item.PT, item.Eta, item.Phi, item.Mass
+
+            p4tot = ROOT.TLorentzVector(0., 0., 0., 0.)
+
+            if self.debug: print '   -> Nconst: ', len(item.Constituents)
+            for j in xrange(len(item.Constituents)):
+                const = item.Constituents.At(j)
+                p4 = ROOT.TLorentzVector(0., 0., 0., 0.)
+                if isinstance(const, ROOT.Track):
+                    p4 = ROOT.Track(const).P4()
+                    if self.debug: print '       Track: ', p4.Pt(), p4.Eta(), p4.Phi(), p4.M()
+
+                if isinstance(const, ROOT.Tower):
+                    p4 = ROOT.Tower(const).P4()
+                    if self.debug: print '       Tower: ', p4.Pt(), p4.Eta(), p4.Phi(), p4.M()           
+
+                if isinstance(const, ROOT.Muon):
+                    p4 = ROOT.Muon(const).P4()
+                    if self.debug: print '       Muon: ', p4.Pt(), p4.Eta(), p4.Phi(), p4.M()            
+                p4tot += p4
+
+            if self.debug : print '   jet const sum: ', p4tot.Pt(), p4tot.Eta(), p4tot.Phi(), p4tot.M()
+            if self.debug : print '   jet          : ', jetp4.Pt(), jetp4.Eta(), jetp4.Phi(), jetp4.M()
+
+            self.jetchs_idpass[i] |= 1 << 0
+            self.jetchs_idpass[i] |= 1 << 1
+            self.jetchs_idpass[i] |= 1 << 2
+
+            i += 1
+        self.jetchs_size[0] = i
 
 
     #___________________________________________
@@ -426,17 +513,25 @@ class TreeProducer:
             i += 1
         self.tau_size[0] = i
 
-
-
     #___________________________________________
-    def processMissingET(self, met):
+    def processPFMissingET(self, met):
         i = 0
         for item in met:
 
-            self.met_pt    [i] = item.MET
-            self.met_phi   [i] = item.Phi
+            self.metpf_pt    [i] = item.MET
+            self.metpf_phi   [i] = item.Phi
             i += 1
-        self.met_size  [0] = i
+        self.metpf_size  [0] = i
+
+    #___________________________________________
+    def processPuppiMissingET(self, met):
+        i = 0
+        for item in met:
+
+            self.metpuppi_pt    [i] = item.MET
+            self.metpuppi_phi   [i] = item.Phi
+            i += 1
+        self.metpuppi_size  [0] = i
 
 
     def fill(self):
@@ -488,6 +583,7 @@ def main():
     branchVertex          = treeReader.UseBranch('Vertex')   
     branchParticle        = treeReader.UseBranch('Particle') 
     branchGenJet          = treeReader.UseBranch('GenJet')   
+    branchGenMissingET    = treeReader.UseBranch('GenMissingET')   
 
     branchPhoton          = treeReader.UseBranch('Photon')
     branchPhotonLoose     = treeReader.UseBranch('PhotonLoose')
@@ -502,16 +598,17 @@ def main():
     branchElectronTight   = branchElectronMedium
     # TO BE FIXED (replace by Tight when available)!!!
 
-
     branchMuon            = treeReader.UseBranch('Muon')
     branchMuonLoose       = treeReader.UseBranch('MuonLoose')
     # TO BE FIXED (replace by Medium when available)!!!
     branchMuonMedium      = branchMuonLoose
     branchMuonTight       = treeReader.UseBranch('MuonTight')
 
-    branchJet            = treeReader.UseBranch('JetPUPPI')
-    #branchJet            = treeReader.UseBranch('Jet')
-    branchMissingET       = treeReader.UseBranch('PuppiMissingET')
+    branchPuppiJet        = treeReader.UseBranch('JetPUPPI')
+    branchCHSJet          = treeReader.UseBranch('Jet')
+
+    branchPuppiMissingET  = treeReader.UseBranch('PuppiMissingET')
+    branchPFMissingET     = treeReader.UseBranch('MissingET')
 
     # NEED these branches to access jet constituents
     branchEFlowTrack = treeReader.UseBranch('EFlowTrack');
@@ -536,12 +633,15 @@ def main():
         treeProducer.processVertices(branchVertex)
         treeProducer.processGenParticles(branchParticle)
         treeProducer.processGenJets(branchGenJet)
+        treeProducer.processGenMissingET(branchGenMissingET)
         treeProducer.processElectrons(branchElectron, branchElectronLoose, branchElectronMedium, branchElectronTight)
         treeProducer.processMuons(branchMuon, branchMuonLoose, branchMuonMedium, branchMuonTight)
         treeProducer.processPhotons(branchPhoton, branchPhotonLoose, branchPhotonMedium, branchPhotonTight)
-        treeProducer.processJets(branchJet)
-        treeProducer.processTaus(branchJet)
-        treeProducer.processMissingET(branchMissingET)
+        treeProducer.processCHSJets(branchCHSJet)
+        treeProducer.processPuppiJets(branchPuppiJet)
+        treeProducer.processTaus(branchPuppiJet)
+        treeProducer.processPFMissingET(branchPFMissingET)
+        treeProducer.processPuppiMissingET(branchPuppiMissingET)
 
         ## fill tree 
         treeProducer.fill()

--- a/cards/CMS_PhaseII_200PU_v04VAL.tcl
+++ b/cards/CMS_PhaseII_200PU_v04VAL.tcl
@@ -131,7 +131,11 @@ set ExecutionPath {
   TauTaggingAK8DNNMedium
   TauTaggingAK8DNNTight
 
-  TauTaggingPUPPICutBased
+  TauTaggingPUPPICutBasedLoose
+  TauTaggingPUPPICutBasedMedium
+  TauTaggingPUPPICutBasedTight
+  TauTaggingPUPPICutBasedVeryTight
+
   TauTaggingPUPPIDNNMedium
   TauTaggingPUPPIDNNTight
 
@@ -3899,7 +3903,7 @@ module TauTagging TauTaggingAK8DNNTight {
 
 
 
-
+##############################################################
 module TauTagging TauTaggingPUPPICutBased {
   set ParticleInputArray Delphes/allParticles
   set PartonInputArray Delphes/partons
@@ -3918,11 +3922,108 @@ module TauTagging TauTaggingPUPPICutBased {
   add EfficiencyFormula {0}  { (abs(eta) < 2.3) * ((( -0.00621816+0.00130097*pt-2.19642e-5*pt^2+1.49393e-7*pt^3-4.58972e-10*pt^4+5.27983e-13*pt^5 )) * (pt<250) + 0.0032*(pt>250)) + \
                                (abs(eta) > 2.3) * (0.000)
                              }
-  add EfficiencyFormula {15} { (abs(eta) < 2.3) * 0.97*0.77*( (0.32 + 0.01*pt - 0.000054*pt*pt )*(pt<100)+0.78*(pt>100) ) + \
+  add EfficiencyFormula {15} { (abs(eta) < 2.3) * 0.97*0.77*( (0.32 + 0.01*pt - 0.000054*pt*pt )*(pt<=100)+0.78*(pt>100) ) + \
                                (abs(eta) > 2.3) * (0.000)
                              }
 }
 
+#############################################################
+module TauTagging TauTaggingPUPPICutBasedLoose {
+  set ParticleInputArray Delphes/allParticles
+  set PartonInputArray Delphes/partons
+  set JetInputArray JetEnergyScalePUPPI/jets
+
+  set DeltaR 0.5
+
+  set TauPTMin 20.0
+
+  set TauEtaMax 2.4
+
+  set BitNumber 0
+
+  # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+
+  add EfficiencyFormula {0}  { (abs(eta) < 2.4) * ((( -0.00621816+0.00130097*pt-2.19642e-5*pt^2+1.49393e-7*pt^3-4.58972e-10*pt^4+5.27983e-13*pt^5 )) * (pt<250) + 0.0032*(pt>250)) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+  add EfficiencyFormula {15} { (abs(eta) < 2.4) * (0.60) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+}
+
+#############################################################
+module TauTagging TauTaggingPUPPICutBasedMedium {
+  set ParticleInputArray Delphes/allParticles
+  set PartonInputArray Delphes/partons
+  set JetInputArray JetEnergyScalePUPPI/jets
+
+  set DeltaR 0.5
+
+  set TauPTMin 20.0
+
+  set TauEtaMax 2.4
+
+  set BitNumber 1
+
+  # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+
+  add EfficiencyFormula {0}  { (abs(eta) < 2.4) * 0.7*((( -0.00621816+0.00130097*pt-2.19642e-5*pt^2+1.49393e-7*pt^3-4.58972e-10*pt^4+5.27983e-13*pt^5 )) * (pt<250) + 0.0032*(pt>250)) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+  add EfficiencyFormula {15} { (abs(eta) < 2.4) * (0.55) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+}
+
+
+#############################################################
+module TauTagging TauTaggingPUPPICutBasedTight {
+  set ParticleInputArray Delphes/allParticles
+  set PartonInputArray Delphes/partons
+  set JetInputArray JetEnergyScalePUPPI/jets
+
+  set DeltaR 0.5
+
+  set TauPTMin 20.0
+
+  set TauEtaMax 2.4
+
+  set BitNumber 2
+
+  # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+
+  add EfficiencyFormula {0}  { (abs(eta) < 2.4) * 0.25*((( -0.00621816+0.00130097*pt-2.19642e-5*pt^2+1.49393e-7*pt^3-4.58972e-10*pt^4+5.27983e-13*pt^5 )) * (pt<250) + 0.0032*(pt>250)) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+  add EfficiencyFormula {15} { (abs(eta) < 2.4) * (0.55) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+}
+
+
+#############################################################
+module TauTagging TauTaggingPUPPICutBasedVeryTight {
+  set ParticleInputArray Delphes/allParticles
+  set PartonInputArray Delphes/partons
+  set JetInputArray JetEnergyScalePUPPI/jets
+
+  set DeltaR 0.5
+
+  set TauPTMin 20.0
+
+  set TauEtaMax 2.4
+
+  set BitNumber 3
+
+  # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+
+  add EfficiencyFormula {0}  { (abs(eta) < 2.4) * 0.15*((( -0.00621816+0.00130097*pt-2.19642e-5*pt^2+1.49393e-7*pt^3-4.58972e-10*pt^4+5.27983e-13*pt^5 )) * (pt<250) + 0.0032*(pt>250)) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+  add EfficiencyFormula {15} { (abs(eta) < 2.4) * (0.55) + \
+                               (abs(eta) > 2.4) * (0.000)
+                             }
+}
 
 module TauTagging TauTaggingPUPPIDNNMedium {
   set ParticleInputArray Delphes/allParticles
@@ -3935,7 +4036,7 @@ module TauTagging TauTaggingPUPPIDNNMedium {
 
   set TauEtaMax 3.0
 
-  set BitNumber 1
+  set BitNumber 4
 
   # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
   add EfficiencyFormula {0} { 
@@ -4040,8 +4141,8 @@ module TauTagging TauTaggingPUPPIDNNTight {
 
   set TauEtaMax 3.0
 
-  set BitNumber 2
-
+  set BitNumber 5
+  
   # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
   add EfficiencyFormula {0} { 
                                   (abs(eta) > 0.00 && abs(eta) <= 0.50) * (pt >  20.00 && pt <=  30.00) * (0.0005) +
@@ -4371,13 +4472,11 @@ module StatusPidFilter GenParticleFilter {
 }
 
 
-##################
+####################
 # ROOT tree writer
-##################
+####################
 
 module TreeWriter TreeWriter {
-
-
 
 # add Branch InputArray BranchName BranchClass
   #add Branch GenParticleFilter/filteredParticles Particle GenParticle


### PR DESCRIPTION
- added genmet collection
- renamed jet and met collections as jetpuppi and metpuppi
- added jetchs collection
- added metpf (computed using all PF candidates)
- added tauID 4 WPs taken from (slide 4):
https://indico.cern.ch/event/828365/contributions/3467168/attachments/1877726/3093065/tau-POG_UPSG-WS.pdf